### PR TITLE
Fix for images of certain quality that could not be rendered overriding lower quality that could be rendered

### DIFF
--- a/src/GMImagePicker/GMAlbumsViewController.cs
+++ b/src/GMImagePicker/GMAlbumsViewController.cs
@@ -362,7 +362,7 @@ namespace GMImagePicker
 					var asset = (PHAsset)assetsFetchResult[_parent._picker.GridSortOrder == SortOrder.Ascending ? numberOfAssets - 1 : 0];
 					cell.SetVideoLayout (asset.MediaType == PHAssetMediaType.Video);
 					_parent._imageManager.RequestImageForAsset (asset, tableCellThumbnailSize1, PHImageContentMode.AspectFill, null, (image, info) => {
-						if (cell.Tag == currentTag) {
+						if (cell.Tag == currentTag && cell.ImageView1 != null && image != null) {
 							cell.ImageView1.Image = image;
 						}
 					});
@@ -374,7 +374,7 @@ namespace GMImagePicker
 						var tableCellThumbnailSize2 = new CGSize (AlbumThumbnailSize2.Width * scale, AlbumThumbnailSize2.Height * 2);
 						asset = (PHAsset)assetsFetchResult [_parent._picker.GridSortOrder == SortOrder.Ascending ? numberOfAssets - 2 : 1];
 						_parent._imageManager.RequestImageForAsset (asset, tableCellThumbnailSize2, PHImageContentMode.AspectFill, null, (image, info) => {
-							if (cell.Tag == currentTag) {
+							if (cell.Tag == currentTag && cell.ImageView2 != null && image != null) {
 								cell.ImageView2.Image = image;
 							}
 						});
@@ -387,7 +387,7 @@ namespace GMImagePicker
 						var tableCellThumbnailSize3 = new CGSize (AlbumThumbnailSize3.Width * scale, AlbumThumbnailSize3.Height * 2);
 						asset = (PHAsset)assetsFetchResult [_parent._picker.GridSortOrder == SortOrder.Ascending ? numberOfAssets - 3 : 2];
 						_parent._imageManager.RequestImageForAsset (asset, tableCellThumbnailSize3, PHImageContentMode.AspectFill, null, (image, info) => {
-							if (cell.Tag == currentTag) {
+							if (cell.Tag == currentTag && cell.ImageView3 != null && image != null) {
 								cell.ImageView3.Image = image;
 							}
 						});

--- a/src/GMImagePicker/GMGridViewController.cs
+++ b/src/GMImagePicker/GMGridViewController.cs
@@ -119,7 +119,7 @@ namespace GMImagePicker
 					UIBarButtonItemStyle.Done,
 					FinishPickingAssets);
 
-				NavigationItem.RightBarButtonItem.Enabled = (_picker.AutoDisableDoneButton ? _picker.SelectedAssets.Any () : true);
+				NavigationItem.RightBarButtonItem.Enabled = !_picker.AutoDisableDoneButton || _picker.SelectedAssets.Any ();
 			} else {
 				var cancelTitle = _picker.CustomCancelButtonTitle ?? "picker.navigation.cancel-button".Translate (defaultValue: "Cancel");
 				NavigationItem.RightBarButtonItem = new UIBarButtonItem (cancelTitle, 
@@ -300,7 +300,7 @@ namespace GMImagePicker
 			}
 		}
 
-		private PHAsset[] GetAssetsAtIndexPaths(IEnumerable<NSIndexPath> indexPaths)
+		private PHAsset[] GetAssetsAtIndexPaths(ICollection<NSIndexPath> indexPaths)
 		{
 			if (!indexPaths.Any()) {
 				return null;

--- a/src/GMImagePicker/GMGridViewController.cs
+++ b/src/GMImagePicker/GMGridViewController.cs
@@ -452,7 +452,7 @@ namespace GMImagePicker
 					null,
 					(image, info) => {
 						// Only update the thumbnail if the cell tag hasn't changed. Otherwise, the cell has been re-used.
-						if (cell.Tag == currentTag) {
+						if (cell.Tag == currentTag && typedCell.ImageView != null && image != null) {
 							typedCell.ImageView.Image = image;
 						}
 					});
@@ -496,10 +496,8 @@ namespace GMImagePicker
 						null,
 						(image, info) => {
 							// Only update the thumbnail if the cell tag hasn't changed. Otherwise, the cell has been re-used.
-							if (cell.Tag == currentTag) {
-								if (cell.ImageView != null) {
-									cell.ImageView.Image = image;
-								}
+							if (cell.Tag == currentTag && cell.ImageView != null && image != null) {
+								cell.ImageView.Image = image;
 							}
 						});
 				}

--- a/src/GMImagePicker/GMImagePickerController.cs
+++ b/src/GMImagePicker/GMImagePickerController.cs
@@ -379,7 +379,7 @@ namespace GMImagePicker
 			var nav = ChildViewControllers [0] as UINavigationController;
 			if (nav != null) {
 				foreach (var vc in nav.ViewControllers) {
-					vc.NavigationItem.RightBarButtonItem.Enabled = AutoDisableDoneButton ? _selectedAssets.Any () : true;
+					vc.NavigationItem.RightBarButtonItem.Enabled = !AutoDisableDoneButton || _selectedAssets.Any ();
 				}
 			}
 		}


### PR DESCRIPTION
This pull request contains a fix for when you run on an old device or an iPhone/iPod build on a iPad.
What happens on scenario's is that there are no images displayed because the highest quality could not be created by the platform, thus setting a null value to the image views.

The fix checks if the image to assign is not null leaving in such a case either with a lower quality or nothing if none could be rendered.

Also contains a few minor changes like:
- ensuring that an enumeration was not executed twice
- Two foreach loops made safer with OfType
- Simplification of a few ternary checks