### PR TITLE
A fix for when the camera roll list is empty

### DIFF
--- a/samples/GMPhotoPicker.Xamarin/Info.plist
+++ b/samples/GMPhotoPicker.Xamarin/Info.plist
@@ -21,6 +21,8 @@
 	</array>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Access media in Photos</string>
+    <key>NSCameraUsageDescription</key>
+    <string>Access camera requested to take a photo.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -45,7 +47,5 @@
 	</array>
 	<key>XSAppIconAssets</key>
 	<string>Resources/Images.xcassets/AppIcons.appiconset</string>
-    <key>NSCameraUsageDescription</key>
-    <string>De app heeft toegang benodigd tot de camera om foto's te nemen.</string>
 </dict>
 </plist>

--- a/samples/GMPhotoPicker.Xamarin/Info.plist
+++ b/samples/GMPhotoPicker.Xamarin/Info.plist
@@ -45,5 +45,7 @@
 	</array>
 	<key>XSAppIconAssets</key>
 	<string>Resources/Images.xcassets/AppIcons.appiconset</string>
+    <key>NSCameraUsageDescription</key>
+    <string>De app heeft toegang benodigd tot de camera om foto's te nemen.</string>
 </dict>
 </plist>

--- a/src/GMImagePicker/GMGridViewController.cs
+++ b/src/GMImagePicker/GMGridViewController.cs
@@ -106,7 +106,7 @@ namespace GMImagePicker
 
 		private void SetupViews ()
 		{
-			CollectionView.Source = new GMGridViewCollectionViewSource (this);
+            CollectionView.Source = new GMGridViewCollectionViewSource (this);
 			CollectionView.BackgroundColor = UIColor.Clear;
 			View.BackgroundColor = _picker.PickerBackgroundColor;
 		}
@@ -196,7 +196,7 @@ namespace GMImagePicker
 		{
 			base.ViewDidAppear (animated);
 
-			if (_picker.GridSortOrder == SortOrder.Ascending)
+            if (_newestItemPath.Section >= 0 && _newestItemPath.Row >= 0 && _newestItemPath.Item >= 0 && _picker.GridSortOrder == SortOrder.Ascending)
 			{
 				// Scroll to bottom (newest images are at the bottom)
 				CollectionView.ScrollToItem(_newestItemPath, UICollectionViewScrollPosition.Bottom, false);
@@ -378,8 +378,11 @@ namespace GMImagePicker
 							if (_picker.GridSortOrder == SortOrder.Ascending)
 							{
 								var item = collectionView.NumberOfItemsInSection(0) - 1;
-								var path = NSIndexPath.FromItemSection(item, 0);
-								collectionView.ScrollToItem(path, UICollectionViewScrollPosition.Bottom, true);
+							    if (item >= 0)
+							    {
+							        var path = NSIndexPath.FromItemSection(item, 0);
+							        collectionView.ScrollToItem(path, UICollectionViewScrollPosition.Bottom, true);
+							    }
 							}
 							else
 							{

--- a/src/GMImagePicker/GMGridViewController.cs
+++ b/src/GMImagePicker/GMGridViewController.cs
@@ -106,7 +106,7 @@ namespace GMImagePicker
 
 		private void SetupViews ()
 		{
-            CollectionView.Source = new GMGridViewCollectionViewSource (this);
+			CollectionView.Source = new GMGridViewCollectionViewSource (this);
 			CollectionView.BackgroundColor = UIColor.Clear;
 			View.BackgroundColor = _picker.PickerBackgroundColor;
 		}
@@ -196,7 +196,7 @@ namespace GMImagePicker
 		{
 			base.ViewDidAppear (animated);
 
-            if (_newestItemPath.Section >= 0 && _newestItemPath.Row >= 0 && _newestItemPath.Item >= 0 && _picker.GridSortOrder == SortOrder.Ascending)
+			if (_newestItemPath.Section >= 0 && _newestItemPath.Row >= 0 && _newestItemPath.Item >= 0 && _picker.GridSortOrder == SortOrder.Ascending)
 			{
 				// Scroll to bottom (newest images are at the bottom)
 				CollectionView.ScrollToItem(_newestItemPath, UICollectionViewScrollPosition.Bottom, false);


### PR DESCRIPTION
A fix for when the camera roll list is empty and the iOS 10 permission description to use the camera for the sample.