### PR TITLE
Fixes crash due to high memory with image loading

### DIFF
--- a/samples/GMPhotoPicker.Xamarin/Info.plist
+++ b/samples/GMPhotoPicker.Xamarin/Info.plist
@@ -21,6 +21,8 @@
 	</array>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Access media in Photos</string>
+    <key>NSCameraUsageDescription</key>
+    <string>Access camera requested to take a photo.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -45,7 +47,5 @@
 	</array>
 	<key>XSAppIconAssets</key>
 	<string>Resources/Images.xcassets/AppIcons.appiconset</string>
-    <key>NSCameraUsageDescription</key>
-    <string>De app heeft toegang benodigd tot de camera om foto's te nemen.</string>
 </dict>
 </plist>

--- a/samples/GMPhotoPicker.Xamarin/Info.plist
+++ b/samples/GMPhotoPicker.Xamarin/Info.plist
@@ -45,5 +45,7 @@
 	</array>
 	<key>XSAppIconAssets</key>
 	<string>Resources/Images.xcassets/AppIcons.appiconset</string>
+    <key>NSCameraUsageDescription</key>
+    <string>De app heeft toegang benodigd tot de camera om foto's te nemen.</string>
 </dict>
 </plist>

--- a/src/GMImagePicker/GMAlbumsViewCell.cs
+++ b/src/GMImagePicker/GMAlbumsViewCell.cs
@@ -23,9 +23,9 @@ namespace GMImagePicker
 		public UIImageView ImageView3 { get; private set; }
 
 		//Video additional information
-		private UIImageView _videoIcon;
-		private UIView _gradientView;
-		private CAGradientLayer _gradient;
+		private readonly UIImageView _videoIcon;
+		private readonly UIView _gradientView;
+		private readonly CAGradientLayer _gradient;
 
 		public override void AwakeFromNib ()
 		{

--- a/src/GMImagePicker/GMAlbumsViewController.cs
+++ b/src/GMImagePicker/GMAlbumsViewController.cs
@@ -273,9 +273,9 @@ namespace GMImagePicker
 			};
 		}
 
-		private NSArray ToNSArray(PHAssetMediaType[] managed)
+		private NSArray ToNSArray(IReadOnlyCollection<PHAssetMediaType> managed)
 		{
-			var mediaTypes = new NSMutableArray ((nuint) _picker.MediaTypes.Length);
+			var mediaTypes = new NSMutableArray ((nuint)managed.Count);
 			foreach (var mediaType in _picker.MediaTypes)
 			{
 			    mediaTypes.Add (FromObject(mediaType));
@@ -356,7 +356,11 @@ namespace GMImagePicker
 					var tableCellThumbnailSize1 = new CGSize (AlbumThumbnailSize1.Width * scale, AlbumThumbnailSize1.Height * scale);
 					var asset = (PHAsset)assetsFetchResult[_parent._picker.GridSortOrder == SortOrder.Ascending ? numberOfAssets - 1 : 0];
 					cell.SetVideoLayout (asset.MediaType == PHAssetMediaType.Video);
-					_parent._imageManager.RequestImageForAsset (asset, tableCellThumbnailSize1, PHImageContentMode.AspectFill, null, (image, info) => {
+                    _parent._imageManager.RequestImageForAsset (asset,
+                        tableCellThumbnailSize1,
+					    PHImageContentMode.AspectFill,
+					    new PHImageRequestOptions { DeliveryMode = PHImageRequestOptionsDeliveryMode.Opportunistic, ResizeMode = PHImageRequestOptionsResizeMode.Fast },
+                        (image, info) => {
 						if (cell.Tag == currentTag && cell.ImageView1 != null && image != null) {
 							cell.ImageView1.Image = image;
 						}
@@ -368,7 +372,11 @@ namespace GMImagePicker
 						// Compute the thumbnail pixel size:
 						var tableCellThumbnailSize2 = new CGSize (AlbumThumbnailSize2.Width * scale, AlbumThumbnailSize2.Height * 2);
 						asset = (PHAsset)assetsFetchResult [_parent._picker.GridSortOrder == SortOrder.Ascending ? numberOfAssets - 2 : 1];
-						_parent._imageManager.RequestImageForAsset (asset, tableCellThumbnailSize2, PHImageContentMode.AspectFill, null, (image, info) => {
+						_parent._imageManager.RequestImageForAsset (asset, 
+                            tableCellThumbnailSize2,
+						    PHImageContentMode.AspectFill,
+						    new PHImageRequestOptions { DeliveryMode = PHImageRequestOptionsDeliveryMode.Opportunistic, ResizeMode = PHImageRequestOptionsResizeMode.Fast },
+                            (image, info) => {
 							if (cell.Tag == currentTag && cell.ImageView2 != null && image != null) {
 								cell.ImageView2.Image = image;
 							}
@@ -381,7 +389,11 @@ namespace GMImagePicker
 						// Compute the thumbnail pixel size:
 						var tableCellThumbnailSize3 = new CGSize (AlbumThumbnailSize3.Width * scale, AlbumThumbnailSize3.Height * 2);
 						asset = (PHAsset)assetsFetchResult [_parent._picker.GridSortOrder == SortOrder.Ascending ? numberOfAssets - 3 : 2];
-						_parent._imageManager.RequestImageForAsset (asset, tableCellThumbnailSize3, PHImageContentMode.AspectFill, null, (image, info) => {
+						_parent._imageManager.RequestImageForAsset (asset, 
+                            tableCellThumbnailSize3,
+						    PHImageContentMode.AspectFill,
+						    new PHImageRequestOptions { DeliveryMode = PHImageRequestOptionsDeliveryMode.Opportunistic, ResizeMode = PHImageRequestOptionsResizeMode.Fast },
+                            (image, info) => {
 							if (cell.Tag == currentTag && cell.ImageView3 != null && image != null) {
 								cell.ImageView3.Image = image;
 							}

--- a/src/GMImagePicker/GMGridViewCell.cs
+++ b/src/GMImagePicker/GMGridViewCell.cs
@@ -34,9 +34,9 @@ namespace GMImagePicker
 
 		public bool IsEnabled { get; set; }
 
-		private static UIFont TitleFont = UIFont.SystemFontOfSize(12f);
-		private static float TitleHeight = 20.0f;
-		private static UIColor TitleColor = UIColor.White;
+		private static readonly UIFont TitleFont = UIFont.SystemFontOfSize(12f);
+		private static readonly float TitleHeight = 20.0f;
+		private static readonly UIColor TitleColor = UIColor.White;
 
 		public GMGridViewCell (IntPtr handle): base (handle)
 		{

--- a/src/GMImagePicker/GMGridViewController.cs
+++ b/src/GMImagePicker/GMGridViewController.cs
@@ -20,7 +20,7 @@ namespace GMImagePicker
 {
 	internal class GMGridViewController: UICollectionViewController, IPHPhotoLibraryChangeObserver
 	{
-		private GMImagePickerController _picker;
+		private readonly GMImagePickerController _picker;
 		private static CGSize AssetGridThumbnailSize;
 		private static UICollectionViewFlowLayout _portraitLayout;
 		private static UICollectionViewFlowLayout _landscapeLayout;
@@ -451,9 +451,9 @@ namespace GMImagePicker
 				var currentTag = cell.Tag;
 				_imageManager.RequestImageForAsset (typedCell.Asset,
 					AssetGridThumbnailSize,
-					PHImageContentMode.AspectFill,
-					null,
-					(image, info) => {
+				    PHImageContentMode.AspectFill,
+				    new PHImageRequestOptions { DeliveryMode = PHImageRequestOptionsDeliveryMode.Opportunistic, ResizeMode = PHImageRequestOptionsResizeMode.Fast },
+                    (image, info) => {
 						// Only update the thumbnail if the cell tag hasn't changed. Otherwise, the cell has been re-used.
 						if (cell.Tag == currentTag && typedCell.ImageView != null && image != null) {
 							typedCell.ImageView.Image = image;
@@ -496,7 +496,7 @@ namespace GMImagePicker
 					_parent._imageManager.RequestImageForAsset (asset,
 						AssetGridThumbnailSize,
 						PHImageContentMode.AspectFill,
-						null,
+						new PHImageRequestOptions { DeliveryMode = PHImageRequestOptionsDeliveryMode.Opportunistic, ResizeMode = PHImageRequestOptionsResizeMode.Fast },
 						(image, info) => {
 							// Only update the thumbnail if the cell tag hasn't changed. Otherwise, the cell has been re-used.
 							if (cell.Tag == currentTag && cell.ImageView != null && image != null) {

--- a/src/GMImagePicker/GMGridViewController.cs
+++ b/src/GMImagePicker/GMGridViewController.cs
@@ -106,7 +106,7 @@ namespace GMImagePicker
 
 		private void SetupViews ()
 		{
-			CollectionView.Source = new GMGridViewCollectionViewSource (this);
+            CollectionView.Source = new GMGridViewCollectionViewSource (this);
 			CollectionView.BackgroundColor = UIColor.Clear;
 			View.BackgroundColor = _picker.PickerBackgroundColor;
 		}
@@ -196,7 +196,7 @@ namespace GMImagePicker
 		{
 			base.ViewDidAppear (animated);
 
-			if (_picker.GridSortOrder == SortOrder.Ascending)
+            if (_newestItemPath.Section >= 0 && _newestItemPath.Row >= 0 && _newestItemPath.Item >= 0 && _picker.GridSortOrder == SortOrder.Ascending)
 			{
 				// Scroll to bottom (newest images are at the bottom)
 				CollectionView.ScrollToItem(_newestItemPath, UICollectionViewScrollPosition.Bottom, false);
@@ -378,8 +378,11 @@ namespace GMImagePicker
 							if (_picker.GridSortOrder == SortOrder.Ascending)
 							{
 								var item = collectionView.NumberOfItemsInSection(0) - 1;
-								var path = NSIndexPath.FromItemSection(item, 0);
-								collectionView.ScrollToItem(path, UICollectionViewScrollPosition.Bottom, true);
+							    if (item >= 0)
+							    {
+							        var path = NSIndexPath.FromItemSection(item, 0);
+							        collectionView.ScrollToItem(path, UICollectionViewScrollPosition.Bottom, true);
+							    }
 							}
 							else
 							{

--- a/src/GMImagePicker/GMGridViewController.cs
+++ b/src/GMImagePicker/GMGridViewController.cs
@@ -106,7 +106,7 @@ namespace GMImagePicker
 
 		private void SetupViews ()
 		{
-            CollectionView.Source = new GMGridViewCollectionViewSource (this);
+			CollectionView.Source = new GMGridViewCollectionViewSource (this);
 			CollectionView.BackgroundColor = UIColor.Clear;
 			View.BackgroundColor = _picker.PickerBackgroundColor;
 		}
@@ -196,7 +196,7 @@ namespace GMImagePicker
 		{
 			base.ViewDidAppear (animated);
 
-            if (_newestItemPath.Section >= 0 && _newestItemPath.Row >= 0 && _newestItemPath.Item >= 0 && _picker.GridSortOrder == SortOrder.Ascending)
+			if (_newestItemPath.Section >= 0 && _newestItemPath.Row >= 0 && _newestItemPath.Item >= 0 && _picker.GridSortOrder == SortOrder.Ascending)
 			{
 				// Scroll to bottom (newest images are at the bottom)
 				CollectionView.ScrollToItem(_newestItemPath, UICollectionViewScrollPosition.Bottom, false);


### PR DESCRIPTION
 Fixes a crash with the GMImagePicker due to memory usage.
The images were loaded with default options like delivery mode Opportunistic and resize mode none what resulted in full size image usage and high memory usage that crashed on high end devices.
This change makes it workable, and images still get better quality a bit later, and no crash occurs.

This might fix: [Memory Issue #14](https://github.com/roycornelissen/GMImagePicker.Xamarin/issues/14)