### PR TITLE
Make compatible with iOS 11

### DIFF
--- a/src/GMImagePicker/GMAlbumsViewCell.cs
+++ b/src/GMImagePicker/GMAlbumsViewCell.cs
@@ -21,6 +21,8 @@ namespace GMImagePicker
 		public UIImageView ImageView1 { get; private set; }
 		public UIImageView ImageView2 { get; private set; }
 		public UIImageView ImageView3 { get; private set; }
+		public new UILabel TextLabel { get; private set; }
+		public new UILabel DetailTextLabel { get; private set; }
 
 		//Video additional information
 		private UIImageView _videoIcon;
@@ -43,8 +45,11 @@ namespace GMImagePicker
 		{
 			Opaque = false;
 			BackgroundColor = UIColor.Clear;
-			TextLabel.BackgroundColor = BackgroundColor;
-			DetailTextLabel.BackgroundColor = BackgroundColor;
+
+			TextLabel = new UILabel { BackgroundColor = BackgroundColor };
+			DetailTextLabel = new UILabel { BackgroundColor = BackgroundColor };
+			ContentView.AddSubviews(TextLabel, DetailTextLabel);
+
 			Accessory = UITableViewCellAccessory.DisclosureIndicator;
 
 			// Border width of 1 pixel:

--- a/src/GMImagePicker/GMGridViewCell.cs
+++ b/src/GMImagePicker/GMGridViewCell.cs
@@ -147,6 +147,10 @@ namespace GMImagePicker
 		{
 			base.LayoutSubviews ();
 			_gradient.Frame = _gradientView.Bounds;
+
+			var cellSize = ContentView.Bounds.Size.Width;
+			ImageView.Frame = new CGRect(0, 0, cellSize, cellSize);
+			ImageView.LayoutIfNeeded();
 		}
 
 		public void Bind (PHAsset asset)

--- a/src/GMImagePicker/GMGridViewController.cs
+++ b/src/GMImagePicker/GMGridViewController.cs
@@ -59,13 +59,20 @@ namespace GMImagePicker
 				screenWidth = picker.View.Bounds.Width;
 				screenHeight = picker.View.Bounds.Height;
 			} else {
+				var insets = UIEdgeInsets.Zero;
+				if (picker.View.RespondsToSelector(new ObjCRuntime.Selector("safeAreaInsets"))) {
+					insets = picker.View.SafeAreaInsets;
+				}
+				var horizontalInsets = insets.Right + insets.Left;
+				var verticalInsets = insets.Bottom + insets.Top;
+
 				if (UIApplication.SharedApplication.StatusBarOrientation == UIInterfaceOrientation.LandscapeLeft ||
 					UIApplication.SharedApplication.StatusBarOrientation == UIInterfaceOrientation.LandscapeRight) {
-					screenHeight = picker.View.Bounds.Width;
-					screenWidth = picker.View.Bounds.Height;
+					screenHeight = picker.View.Bounds.Width - horizontalInsets;
+					screenWidth = picker.View.Bounds.Height - verticalInsets;
 				} else {
-					screenWidth = picker.View.Bounds.Width;
-					screenHeight = picker.View.Bounds.Height;
+					screenWidth = picker.View.Bounds.Width - horizontalInsets;
+					screenHeight = picker.View.Bounds.Height - verticalInsets;
 				}
 			}
 
@@ -85,6 +92,10 @@ namespace GMImagePicker
 						ItemSize = itemSize,
 						MinimumLineSpacing = (nfloat) spaceWidth
 					};
+
+					if (_portraitLayout.RespondsToSelector(new ObjCRuntime.Selector("sectionInsetReference"))) {
+						_portraitLayout.SectionInsetReference = UICollectionViewFlowLayoutSectionInsetReference.SafeArea;
+					}
 				}
 				return _portraitLayout;
 			} else {
@@ -99,6 +110,10 @@ namespace GMImagePicker
 						ItemSize = itemSize,
 						MinimumLineSpacing = (nfloat) spaceWidth
 					};
+
+					if (_landscapeLayout.RespondsToSelector(new ObjCRuntime.Selector("sectionInsetReference"))) {
+						_landscapeLayout.SectionInsetReference = UICollectionViewFlowLayoutSectionInsetReference.SafeArea;
+					}
 				}
 				return _landscapeLayout;
 			}


### PR DESCRIPTION
Fixes #16.

* GMAlbumsViewCell now has its own TextLabel and DetailTextLabel, which avoids unwanted frame adjustments.
* The grid view now respects the safe area on iOS 11, for compatibility with the iPhone X. Earlier iOS versions are unchanged.
* GMGridViewCell now updates the frame of the ImageView on every layout.