### PR TITLE
Fix crash on camera button pressed

### DIFF
--- a/src/GMImagePicker/GMAlbumsViewController.cs
+++ b/src/GMImagePicker/GMAlbumsViewController.cs
@@ -435,7 +435,7 @@ namespace GMImagePicker
 				var gridViewController = new GMGridViewController (_parent._picker);
 
 				// Set the title
-				gridViewController.Title = cell.TextLabel.Text;
+				gridViewController.Title = _parent._collectionsFetchResultsTitles[indexPath.Section][indexPath.Row];
 				// Use the prefetched assets!
 				gridViewController.AssetsFetchResults = _parent._collectionsFetchResultsAssets [indexPath.Section] [indexPath.Row];
 


### PR DESCRIPTION
When the album list is scrolled down so that first (index path 0-0) album (all photos) is invisible
and user presses camera button then SelectAllAlbumsCell and RowSelected crashes cause CellAt returns null for invisible cell.
Use stored titles instead.