### PR TITLE
Raise GMImagePickerController.Canceled when the view is closed by pulling it down on iOS 13

### DIFF
--- a/src/GMPhotoPicker.Xamarin.UITests/GMPhotoPicker.Xamarin.UITests.csproj
+++ b/src/GMPhotoPicker.Xamarin.UITests/GMPhotoPicker.Xamarin.UITests.csproj
@@ -35,7 +35,7 @@
       <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.UITest">
-      <HintPath>..\packages\Xamarin.UITest.3.0.4\lib\net45\Xamarin.UITest.dll</HintPath>
+      <HintPath>..\packages\Xamarin.UITest.3.0.7\lib\net45\Xamarin.UITest.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/GMPhotoPicker.Xamarin.UITests/packages.config
+++ b/src/GMPhotoPicker.Xamarin.UITests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="3.12.0" targetFramework="net45" />
-  <package id="Xamarin.UITest" version="3.0.4" targetFramework="net45" />
+  <package id="Xamarin.UITest" version="3.0.7" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This fix keeps track of whether FinishPickingAssets was called to dismiss the controller. If it wasn't the Canceled event will be raised in ViewDidDisappear.

See https://github.com/roycornelissen/GMImagePicker.Xamarin/issues/74